### PR TITLE
Removing toolchain version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/openshift/ocm-agent
 
 go 1.22.0
 
-toolchain go1.22.6
-
 require (
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0


### PR DESCRIPTION
Removing the toolchain version for now considering the local go tool version will be referred to.

